### PR TITLE
Potential fix for code scanning alert no. 9: Log entries created from user input

### DIFF
--- a/src/Genesis/Middlewares/GlobalExceptionHandlerMiddleware.cs
+++ b/src/Genesis/Middlewares/GlobalExceptionHandlerMiddleware.cs
@@ -43,6 +43,8 @@ namespace Blocks.Genesis
                 context.Request.Body.Position = 0;
                 using var reader = new StreamReader(context.Request.Body, Encoding.UTF8, leaveOpen: true);
                 requestPayload = await reader.ReadToEndAsync();
+                // Remove carriage return and new line characters to prevent log forging
+                requestPayload = requestPayload.Replace("\r", "").Replace("\n", "");
                 context.Request.Body.Position = 0;
             }
 


### PR DESCRIPTION
Potential fix for [https://github.com/SELISEdigitalplatforms/l0-net-blocks-genesis/security/code-scanning/9](https://github.com/SELISEdigitalplatforms/l0-net-blocks-genesis/security/code-scanning/9)

To prevent log-forging vulnerabilities, any user input included in a log message should have newlines and other control characters removed or sanitized. In this case, before including `requestPayload` (the user-provided request body) in the log message, replace `\r`, `\n`, and (optionally) other problematic control characters with safe substitutes (often an empty string, a space, or visible markers such as `\n` replaced with `\\n`). The change should happen right after `requestPayload` is read (lines 44–47), before it's interpolated into the log message (line 55). 

Add:
- A single line after reading the payload, replacing line breaks with empty strings (use `Replace` for `\r` and `\n`).
- No additional dependencies or imports are required as we are only using standard string methods.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
