### PR TITLE
fix(ci): pin unpinned actions and stop CI on push

### DIFF
--- a/.github/workflows/1_test.yml
+++ b/.github/workflows/1_test.yml
@@ -60,7 +60,7 @@ jobs:
           find . -type f
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         if: always()
         with:
           files: "**/*.trx"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,6 @@
 name: Build (main)
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Publish NuGet package
 
 on:
-  push:
-    branches:
-      - inception
   release:
     types: [published]
   workflow_dispatch:
@@ -37,7 +34,7 @@ jobs:
 
       - name: NuGet login (OIDC to temporary API key)
         id: login
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
           user: selise-devops
 

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -1,9 +1,11 @@
 name: repo-hygiene
 on:
-  push:
-    branches: [inception]
   pull_request:
     branches: [inception, main]
+
+permissions:
+  contents: read
+
 jobs:
   repo-hygiene:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ports the workflow security fixes already pushed to `main` (`3fca434`) onto `inception`. Cherry-picked, so this carries only those changes — no unrelated `main` → `inception` drift.

### Code-scanning alerts

Both open alerts were `actions/unpinned-tag`:

| Alert | File | Change |
| --- | --- | --- |
| #15 | `1_test.yml:63` | `EnricoMi/publish-unit-test-result-action@v2` → `@d0a4676` (v2.24.0) |
| #17 | `release.yml:40` | `NuGet/login@v1` → `@8d19675` (v1.2.0) |

### No CI on push

- **`main.yml`** — dropped `push: main`, kept `pull_request`.
- **`release.yml`** — dropped `push: inception`. Publishing now runs on `release: published` or `workflow_dispatch`.
- **`repo-hygiene.yml`** — dropped `push: inception`, kept `pull_request`, and added a top-level `permissions: contents: read` (alert #16 was dismissed for this file, but the block costs nothing).

`unit-test.yml` keeps its `push: feature/unit-test` trigger — it never fires on `main`, and removing it would leave the workflow with no trigger at all.

The reusable workflows (`1_test`, `2_sonar`, `3_security`) already carry job-level permissions and are otherwise untouched.