### PR TITLE
ci: run mongodb, redis and rabbitmq as service containers for tests

### DIFF
--- a/.github/workflows/1_test.yml
+++ b/.github/workflows/1_test.yml
@@ -4,6 +4,42 @@ jobs:
   build:
     name: Test Execution
     runs-on: ubuntu-latest
+
+    # The suite talks to real MongoDB, Redis and RabbitMQ on localhost default
+    # ports (see docker-compose.yml). Without these the service-backed tests
+    # fail with "Connection refused". No credentials: the tests use anonymous
+    # mongodb://localhost:27017, redis on 6379 and RabbitMQ's default guest user.
+    services:
+      mongodb:
+        image: mongo:7.0
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.adminCommand({ ping: 1 })'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
+
+      redis:
+        image: redis:7.4
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
+
+      rabbitmq:
+        image: rabbitmq:3.13-management
+        ports:
+          - 5672:5672
+          - 15672:15672
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 12
     permissions: 
       contents: read 
       checks: write 

--- a/.github/workflows/2_sonar.yml
+++ b/.github/workflows/2_sonar.yml
@@ -17,6 +17,42 @@ jobs:
   build:
     name: SonarQube Analysis
     runs-on: ubuntu-latest
+
+    # The suite talks to real MongoDB, Redis and RabbitMQ on localhost default
+    # ports (see docker-compose.yml). Without these the service-backed tests
+    # fail with "Connection refused". No credentials: the tests use anonymous
+    # mongodb://localhost:27017, redis on 6379 and RabbitMQ's default guest user.
+    services:
+      mongodb:
+        image: mongo:7.0
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.adminCommand({ ping: 1 })'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
+
+      redis:
+        image: redis:7.4
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
+
+      rabbitmq:
+        image: rabbitmq:3.13-management
+        ports:
+          - 5672:5672
+          - 15672:15672
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 12
     permissions:
       contents: read
       checks: write


### PR DESCRIPTION
The suite connects to real MongoDB, Redis and RabbitMQ on localhost default ports, so on the runner every service-backed test failed with Connection refused (48 occurrences in the last run), taking down both the test job and the SonarQube job. Images and ports mirror docker-compose.yml; no credentials are configured because the tests use anonymous localhost connections and RabbitMQ's default guest user.