### PR TITLE
Measure coverage across Blocks.Genesis and split out the Mongo integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,13 @@ zap-*.xml
 
 # local security scan tooling (contains credentials, never commit)
 scripts/scan.sh
+
+# --- local AI / scan workspace (do not commit) ---
+.env
+.env.*
+!.env.example
+
+# --- AI agent instruction files (do not commit) ---
+QWEN.md
+.clinerules
+.windsurfrules

--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,8 @@ _pkginfo.txt
 
 # Local test output
 test-results.xml
+results/
+coverage/
 
 */node_modules
 # --- AI assistant artifacts: never track ---

--- a/src/XUnitTest/Health/GenesisHealthPingBackgroundServiceCoverageTests.cs
+++ b/src/XUnitTest/Health/GenesisHealthPingBackgroundServiceCoverageTests.cs
@@ -15,6 +15,7 @@ public class GenesisHealthPingBackgroundServiceCoverageTests
     private const string MongoConnectionString = "mongodb://127.0.0.1:27017";
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task LoadConfigurationFromDatabaseAsync_ShouldApplyConfigAndWriteThroughToCache()
     {
         var databaseName = $"health-ping-tests-{Guid.NewGuid():N}";
@@ -49,6 +50,7 @@ public class GenesisHealthPingBackgroundServiceCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task LoadConfigurationFromDatabaseAsync_ShouldKeepConfig_WhenCacheWriteFails()
     {
         var databaseName = $"health-ping-tests-{Guid.NewGuid():N}";
@@ -88,6 +90,7 @@ public class GenesisHealthPingBackgroundServiceCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task LoadConfigurationFromDatabaseAsync_ShouldLeaveConfigNull_WhenDocumentMissing()
     {
         var databaseName = $"health-ping-tests-{Guid.NewGuid():N}";
@@ -220,6 +223,7 @@ public class GenesisHealthPingBackgroundServiceCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task ExecuteAsync_ShouldKeepPolling_ThroughNoConfigDisabledAndEmptyEndpointBranches()
     {
         var databaseName = $"health-loop-{Guid.NewGuid():N}";

--- a/src/XUnitTest/Lmt/LmtConfigurationCoverageTests.cs
+++ b/src/XUnitTest/Lmt/LmtConfigurationCoverageTests.cs
@@ -26,6 +26,7 @@ public class LmtConfigurationCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public void CreateCollectionForTrace_ShouldCreateTimeSeriesCollectionAndIndex_AndBeIdempotent()
     {
         var collectionName = $"trace-cov-{Guid.NewGuid():N}";
@@ -48,6 +49,7 @@ public class LmtConfigurationCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public void CreateCollectionForTrace_ShouldRecreateCollection_WhenExistingIsNotTimeSeries()
     {
         var collectionName = $"trace-recreate-{Guid.NewGuid():N}";
@@ -68,6 +70,7 @@ public class LmtConfigurationCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public void CreateCollectionForMetrics_ShouldCreateTimeSeriesCollection()
     {
         var collectionName = $"metrics-cov-{Guid.NewGuid():N}";
@@ -86,6 +89,7 @@ public class LmtConfigurationCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public void CreateCollectionForLogs_ShouldCreateTimeSeriesCollectionWithPartialIndex()
     {
         var collectionName = $"logs-cov-{Guid.NewGuid():N}";
@@ -144,6 +148,7 @@ public class LmtConfigurationCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public void CreateIndex_ShouldSkipCreation_WhenExistingKeySpecWasNormalizedByServer()
     {
         var collectionName = $"idx-equivalent-{Guid.NewGuid():N}";
@@ -179,6 +184,7 @@ public class LmtConfigurationCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public void CreateIndex_ShouldSkipCreation_WhenIndexWithSameKeysExistsUnderDifferentName()
     {
         var collectionName = $"idx-samekeys-{Guid.NewGuid():N}";
@@ -208,6 +214,7 @@ public class LmtConfigurationCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public void CreateIndex_ShouldWarnAndContinue_WhenEquivalentKeyPatternExistsWithDifferentName()
     {
         var collectionName = $"idx-equivalent-{Guid.NewGuid():N}";
@@ -239,6 +246,7 @@ public class LmtConfigurationCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public void CreateIndex_ShouldSkipCreation_WhenIndexWithSameNameExists()
     {
         var collectionName = $"idx-samename-{Guid.NewGuid():N}";

--- a/src/XUnitTest/Lmt/MongoDBDynamicSinkCoverageTests.cs
+++ b/src/XUnitTest/Lmt/MongoDBDynamicSinkCoverageTests.cs
@@ -43,6 +43,7 @@ public class MongoDBDynamicSinkCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task EmitBatchAsync_ShouldPersistToMongo_WithFilteredProperties()
     {
         var previousServiceBus = Environment.GetEnvironmentVariable("ServiceBusConnectionString");
@@ -74,6 +75,7 @@ public class MongoDBDynamicSinkCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task SaveToMongoDBAsync_ShouldConvertAllPropertyKinds_AndFallBackWhenConversionThrows()
     {
         var previousServiceBus = Environment.GetEnvironmentVariable("ServiceBusConnectionString");

--- a/src/XUnitTest/Lmt/MongoDBTraceExporterCoverageTests.cs
+++ b/src/XUnitTest/Lmt/MongoDBTraceExporterCoverageTests.cs
@@ -13,6 +13,7 @@ public class MongoDBTraceExporterCoverageTests
     private const string UnreachableConnectionString = "mongodb://127.0.0.1:1/?serverSelectionTimeoutMS=200&connectTimeoutMS=200";
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task FlushBatchAsync_ShouldPersistQueuedTraces_ToMongo_WhenNoServiceBusIsConfigured()
     {
         var previousServiceBus = Environment.GetEnvironmentVariable("ServiceBusConnectionString");
@@ -80,6 +81,7 @@ public class MongoDBTraceExporterCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public void Dispose_ShouldFlushPendingTraces_AndBeIdempotent()
     {
         var previousServiceBus = Environment.GetEnvironmentVariable("ServiceBusConnectionString");

--- a/src/XUnitTest/Middlewares/OnboardingApiAccessMiddlewareTests.cs
+++ b/src/XUnitTest/Middlewares/OnboardingApiAccessMiddlewareTests.cs
@@ -327,6 +327,7 @@ public class OnboardingApiAccessMiddlewareTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task InvokeAsync_ShouldLoadAllowedApisFromRootDatabase_WhenDocumentHasAllowedApis()
     {
         var databaseName = $"onboarding-mw-tests-{Guid.NewGuid():N}";
@@ -373,6 +374,7 @@ public class OnboardingApiAccessMiddlewareTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task InvokeAsync_ShouldFallBackToEmptyAllowedApis_WhenDocumentIsMissing()
     {
         var databaseName = $"onboarding-mw-tests-{Guid.NewGuid():N}";
@@ -412,6 +414,7 @@ public class OnboardingApiAccessMiddlewareTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task InvokeAsync_ShouldFallBackToEmptyAllowedApis_WhenAllowedApisIsNotAnArray()
     {
         var databaseName = $"onboarding-mw-tests-{Guid.NewGuid():N}";

--- a/src/XUnitTest/Tenant/TenantsCoverageTests.cs
+++ b/src/XUnitTest/Tenant/TenantsCoverageTests.cs
@@ -23,6 +23,7 @@ public class TenantsCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task GetTenantByID_ShouldLoadFromDatabase_ThenServeFromCache()
     {
         var databaseName = $"tenants-cov-{Guid.NewGuid():N}";
@@ -59,6 +60,7 @@ public class TenantsCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public void GetTenantByID_ShouldReturnNull_WhenTenantDoesNotExist()
     {
         var databaseName = $"tenants-cov-{Guid.NewGuid():N}";
@@ -97,6 +99,7 @@ public class TenantsCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public void GetTenantDatabaseConnectionString_ShouldReturnNulls_WhenTenantMissing()
     {
         var databaseName = $"tenants-cov-{Guid.NewGuid():N}";
@@ -209,6 +212,7 @@ public class TenantsCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task GetTenantByApplicationDomain_ShouldFindTenantInDatabase_ThenServeFromCache()
     {
         var databaseName = $"tenants-cov-{Guid.NewGuid():N}";
@@ -246,6 +250,7 @@ public class TenantsCoverageTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
     public async Task EnsureTraceCollectionExistsAsync_ShouldCreateTraceCollection_ForRecentTenant()
     {
         var tenantId = $"trace-tenant-{Guid.NewGuid():N}";

--- a/src/XUnitTest/XUnitTest.csproj
+++ b/src/XUnitTest/XUnitTest.csproj
@@ -5,6 +5,12 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+
+    <!-- Copy framework and package assemblies next to the test binaries so coverlet's Cecil
+         resolver can load every reference of Blocks.Genesis. Without this, instrumentation of
+         Blocks.Genesis fails and the coverage report silently covers only Blocks.LMT.Client. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Brings `inception` up to `dev` for blocks-genesis-net.

## Commits
- test(be): measure coverage across Blocks.Genesis and mark Mongo tests as integration

## Verification
- Backend unit tests: 898 passed, 0 failed (`dotnet test src/blocks-genesis-net.sln`, integration tests excluded).
- gitleaks and trufflehog run locally before pushing. No verified secrets, and no findings introduced by these commits.
